### PR TITLE
Change from static mock data to db persistence

### DIFF
--- a/studyquest/app/mock_data.py
+++ b/studyquest/app/mock_data.py
@@ -1,49 +1,65 @@
 from datetime import date, timedelta
-from .models import Quest
+from .models import Quest, User
+from . import db
 
 DEFAULT_STATUS = "In Progress"
 
-mock_quests = [
-    Quest(
-        id=1,
-        title="Labwork",
-        description="Complete weekly lab tasks",
-        quest_type="study",
-        difficulty="easy",
-        due_date=date.today() - timedelta(days=1),  
-        status=DEFAULT_STATUS,
-        start_date=date.today() - timedelta(days=4)
-    ),
+def create_mock_quests():
+    # Check if the specific mock user exists
+    user = User.query.filter_by(username="mockuser").first()
+    if not user:
+        user = User(username="mockuser")
+        user.set_password("password")  # Set a default password
+        db.session.add(user)
+        db.session.commit()  # Commit to get user.id
 
-    Quest(
-        id=2,
-        title="Essay draft",
-        description="Write first essay draft",
-        quest_type="assignment",
-        difficulty="medium",
-        status=DEFAULT_STATUS,
-        start_date=date.today() - timedelta(days=2)
-    ),
-
-    Quest(
-        id=3,
-        title="Midsem revision",
-        description="Revise lecture material",
-        quest_type="exam",
-        difficulty="hard",
-        due_date=date.today() + timedelta(days=2),  # Use date instead of datetime
-        status=DEFAULT_STATUS,
-        start_date=date.today() 
-    ),
+    # Check if the specific quests already exist for this user
+    existing_titles = {q.title for q in Quest.query.filter_by(user_id=user.id).all()}
     
-    Quest(
-        id=4,
-        title="Group project",
-        description="Finish report section",
-        quest_type="assignment",
-        difficulty="medium",
-        due_date=date.today() + timedelta(days=10),  # Use date instead of datetime
-        status=DEFAULT_STATUS,
-        start_date=date.today() 
-    )
-]
+    mock_quests_data = [
+        {
+            "title": "Labwork",
+            "description": "Complete weekly lab tasks",
+            "quest_type": "study",
+            "difficulty": "easy",
+            "start_date": date.today() - timedelta(days=4),
+            "due_date": date.today() - timedelta(days=1),
+        },
+        {
+            "title": "Essay draft",
+            "description": "Write first essay draft",
+            "quest_type": "assignment",
+            "difficulty": "medium",
+            "start_date": date.today() - timedelta(days=2),
+        },
+        {
+            "title": "Midsem revision",
+            "description": "Revise lecture material",
+            "quest_type": "exam",
+            "difficulty": "hard",
+            "start_date": date.today(),
+            "due_date": date.today() + timedelta(days=2),
+        },
+        {
+            "title": "Group project",
+            "description": "Finish report section",
+            "quest_type": "assignment",
+            "difficulty": "medium",
+            "start_date": date.today(),
+            "due_date": date.today() + timedelta(days=10),
+        },
+    ]
+
+    # Only create quests that don't already exist for this user
+    new_quests = []
+    for data in mock_quests_data:
+        if data["title"] not in existing_titles:
+            new_quests.append(Quest(user_id=user.id, status=DEFAULT_STATUS, **data))
+
+    if not new_quests:
+        print("All mock quests already exist. Skipping creation.")
+        return
+
+    db.session.add_all(new_quests)
+    db.session.commit()
+    print(f"Added {len(new_quests)} new mock quest(s) for {user.username}!")

--- a/studyquest/app/mock_data.py
+++ b/studyquest/app/mock_data.py
@@ -1,5 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 from .models import Quest
+
+DEFAULT_STATUS = "In Progress"
 
 mock_quests = [
     Quest(
@@ -8,7 +10,9 @@ mock_quests = [
         description="Complete weekly lab tasks",
         quest_type="study",
         difficulty="easy",
-        due_date=datetime.now() + timedelta(days=-1)  
+        due_date=date.today() - timedelta(days=1),  
+        status=DEFAULT_STATUS,
+        start_date=date.today() - timedelta(days=4)
     ),
 
     Quest(
@@ -17,6 +21,8 @@ mock_quests = [
         description="Write first essay draft",
         quest_type="assignment",
         difficulty="medium",
+        status=DEFAULT_STATUS,
+        start_date=date.today() - timedelta(days=2)
     ),
 
     Quest(
@@ -25,7 +31,9 @@ mock_quests = [
         description="Revise lecture material",
         quest_type="exam",
         difficulty="hard",
-        due_date=datetime.now() + timedelta(days=2)  
+        due_date=date.today() + timedelta(days=2),  # Use date instead of datetime
+        status=DEFAULT_STATUS,
+        start_date=date.today() 
     ),
     
     Quest(
@@ -34,6 +42,8 @@ mock_quests = [
         description="Finish report section",
         quest_type="assignment",
         difficulty="medium",
-        due_date=datetime.now() + timedelta(days=10)  
+        due_date=date.today() + timedelta(days=10),  # Use date instead of datetime
+        status=DEFAULT_STATUS,
+        start_date=date.today() 
     )
 ]

--- a/studyquest/app/models.py
+++ b/studyquest/app/models.py
@@ -10,14 +10,20 @@ class Quest(db.Model):
     description = db.Column(db.Text, nullable=False)
     quest_type = db.Column(db.String(50), nullable=False)
     difficulty = db.Column(db.String(50), nullable=False)
+    start_date = db.Column(db.Date, nullable=False, default=date.today)
     due_date = db.Column(db.Date, nullable=True)
     status = db.Column(db.String(50), default="In Progress")
     date_completed = db.Column(db.Date, nullable=True)
+
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', back_populates='quests')
 
 class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(200), nullable=False)
+
+    quests = db.relationship('Quest', back_populates='user')
 
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)

--- a/studyquest/app/routes.py
+++ b/studyquest/app/routes.py
@@ -1,62 +1,52 @@
-from app import app
+from app import app, db
 from flask import render_template
-from datetime import date, timedelta
+from datetime import date
+from app.models import Quest  
 
-### TODO: remove/edit when DB is implemented
-from app.mock_data import mock_quests
-
-# Filter quests based on their status
-active_quests = [q for q in mock_quests if q.status == "In Progress"]
-print(active_quests[0].start_date)  # You may need to check for `start_date` or `due_date`
-
-completed_quests = [q for q in mock_quests if q.status == "Completed"]
-
-# Sort quests by due_date (ascending) - we compare dates only
-active_quests_with_due_date = sorted(
-    [q for q in active_quests if q.due_date], key=lambda x: x.due_date
-)
-completed_quests_with_due_date = sorted(
-    [q for q in completed_quests if q.due_date], key=lambda x: x.due_date
-)
-
-# Quests with no due date
-active_quests_no_due_date = [q for q in active_quests if not q.due_date]
-completed_quests_no_due_date = [q for q in completed_quests if not q.due_date]
-
-# Overdue quests (ensure due_date exists and compare with current date)
-overdue_quests = [
-    q for q in mock_quests if q.due_date and q.due_date < date.today() and q.status != "Completed"
-]
-overdue_quests_sorted = sorted(overdue_quests, key=lambda x: x.due_date)
-
-# Count quests
-total_quests = len(mock_quests)
-active_count = len(active_quests)
-completed_count = len(completed_quests)
-overdue_count = len(overdue_quests)
-
-###
-
-@app.route("/")  # TODO: Change when login is properly implemented
+@app.route("/") 
 @app.route("/dashboard")
 def dashboard():
-    return render_template(
-        'dashboard.html', quests=active_quests_with_due_date
-    )
+    # Query database for active quests with due dates, ordered by due date
+    active_quests = Quest.query.filter_by(status="In Progress")\
+        .filter(Quest.due_date.isnot(None))\
+        .order_by(Quest.due_date.asc()).all()
+        
+    return render_template('dashboard.html', quests=active_quests)
 
 @app.route("/my-quests")
 def my_quests():
+    active_q = Quest.query.filter_by(status="In Progress").all()
+    completed_q = Quest.query.filter_by(status="Completed").all()
+    
+    active_with_due = sorted([q for q in active_q if q.due_date], key=lambda x: x.due_date)
+    active_no_due = [q for q in active_q if not q.due_date]
+    
+    completed_with_due = sorted([q for q in completed_q if q.due_date], key=lambda x: x.due_date)
+    completed_no_due = [q for q in completed_q if not q.due_date]
+    
+    overdue_quests = Quest.query.filter(
+        Quest.status != "Completed",
+        Quest.due_date < date.today()
+    ).order_by(Quest.due_date.asc()).all()
+
+    counts = {
+        "total": Quest.query.count(),
+        "active": len(active_q),
+        "completed": len(completed_q),
+        "overdue": len(overdue_quests)
+    }
+
     return render_template(
         "my_quests.html",
-        active_quests_with_due_date=active_quests_with_due_date,
-        active_quests_no_due_date=active_quests_no_due_date,
-        completed_quests_with_due_date=completed_quests_with_due_date,
-        completed_quests_no_due_date=completed_quests_no_due_date,
-        overdue_quests=overdue_quests_sorted,
-        total_quests=total_quests,
-        active_count=active_count,
-        completed_count=completed_count,
-        overdue_count=overdue_count
+        active_quests_with_due_date=active_with_due,
+        active_quests_no_due_date=active_no_due,
+        completed_quests_with_due_date=completed_with_due,
+        completed_quests_no_due_date=completed_no_due,
+        overdue_quests=overdue_quests,
+        total_quests=counts["total"],
+        active_count=counts["active"],
+        completed_count=counts["completed"],
+        overdue_count=counts["overdue"]
     )
 
 @app.route("/create-quest")

--- a/studyquest/app/routes.py
+++ b/studyquest/app/routes.py
@@ -1,26 +1,31 @@
 from app import app
 from flask import render_template
-from datetime import datetime
+from datetime import date, timedelta
 
 ### TODO: remove/edit when DB is implemented
 from app.mock_data import mock_quests
 
+# Filter quests based on their status
 active_quests = [q for q in mock_quests if q.status == "In Progress"]
+print(active_quests[0].start_date)  # You may need to check for `start_date` or `due_date`
+
 completed_quests = [q for q in mock_quests if q.status == "Completed"]
 
-# Sort quests by due_date (ascending)
+# Sort quests by due_date (ascending) - we compare dates only
 active_quests_with_due_date = sorted(
     [q for q in active_quests if q.due_date], key=lambda x: x.due_date
 )
 completed_quests_with_due_date = sorted(
     [q for q in completed_quests if q.due_date], key=lambda x: x.due_date
 )
+
 # Quests with no due date
 active_quests_no_due_date = [q for q in active_quests if not q.due_date]
 completed_quests_no_due_date = [q for q in completed_quests if not q.due_date]
-# Overdue quests (ensure due_date exists)
+
+# Overdue quests (ensure due_date exists and compare with current date)
 overdue_quests = [
-    q for q in mock_quests if q.due_date and q.due_date.date() < datetime.now().date() and q.status != "Completed"
+    q for q in mock_quests if q.due_date and q.due_date < date.today() and q.status != "Completed"
 ]
 overdue_quests_sorted = sorted(overdue_quests, key=lambda x: x.due_date)
 


### PR DESCRIPTION
Updated database structure in models.py: 
- Established a one-to-many relationship between Student and Quest (through FK and relationships)
- changed from using datetime to using date
- added attribute start_date to Quest

Updated dashboard and my_quests in routes.py to query the database directly instead of reading from a local list.

Updated mock_data.py from a static list to a create_mock_quests() function that when called writes data to db. Function prevents duplicate entries if calling multiple times.
Test by:
- Run `flask shell`
- Import and run `create_mock_quests()`
- Lanch app (`flask run`) and check out dashboard page and my quests page
- Can check data persistence after restarting application

To do: currently, the app defaults to a mockuser created by calling create_mock_quests(). We must update to handle user sessions, allowing users to see only their own quests. 
