### PR TITLE
Tests for leaderboard, profile, search, and xp_helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,12 @@ __pycache__/
 
 # Virtual environment
 venv/
+.venv/
 application-env/
+
+# pytest
+.pytest_cache/
+selenium_test.db
 
 # Flask instance/data (if any later)
 instance/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # CITS3403-Group-Project
 Group project for UWA CITS3403 sem1 2026
+
+## Running the tests
+
+```bash
+cd studyquest
+python -m venv .venv
+.venv/Scripts/activate          # Windows PowerShell: .\.venv\Scripts\Activate.ps1
+pip install -r ../requirements.txt
+pytest tests/test_xp_helpers.py tests/test_routes.py -v
+```
+
+That runs 21 unit tests (11 helper-function tests + 10 Flask test-client integration tests).
+
+### Selenium browser tests
+
+The selenium suite spins up a real Flask server on port 5050 with two seeded users (`alice`, `bob`, password `password1!` for both) and drives headless Chrome against it.
+
+Requires Chrome (or Chromium) installed locally. Selenium Manager auto-fetches chromedriver, no separate install needed.
+
+```bash
+cd studyquest
+pytest tests/test_selenium.py -v
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,6 @@ MarkupSafe==3.0.3
 Werkzeug==3.1.8
 WTForms==3.2.1
 Flask-Migrate==4.0.5
+
+pytest==8.3.4
+selenium==4.27.1

--- a/studyquest/tests/conftest.py
+++ b/studyquest/tests/conftest.py
@@ -1,0 +1,82 @@
+"""
+Shared pytest fixtures for the studyquest tests.
+
+The Flask app is created at module-import time and binds to the database URI
+from `Config` immediately, so we must set DATABASE_URL via env BEFORE the
+first `from app import ...` happens. That's why the env tweaks below run at
+top of file, before any other import.
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Make `from app import app` resolvable when pytest is run from anywhere.
+_HERE = Path(__file__).resolve().parent
+_STUDYQUEST_DIR = _HERE.parent
+sys.path.insert(0, str(_STUDYQUEST_DIR))
+
+# Use a throwaway sqlite file just for tests, so we never touch app.db.
+_test_db_fd, _test_db_path = tempfile.mkstemp(suffix=".db", prefix="sq_test_")
+os.close(_test_db_fd)
+os.environ["DATABASE_URL"] = f"sqlite:///{_test_db_path}"
+os.environ["SECRET_KEY"] = "test-secret-key"
+
+import pytest
+from app import app as flask_app, db
+from app.models import User, Quest
+
+flask_app.config["TESTING"] = True
+flask_app.config["WTF_CSRF_ENABLED"] = False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _schema():
+    """Create tables once for the whole test run, drop them at the end."""
+    with flask_app.app_context():
+        db.create_all()
+    yield
+    with flask_app.app_context():
+        db.drop_all()
+    try:
+        os.unlink(_test_db_path)
+    except OSError:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_db():
+    """Wipe data between tests so each one starts from an empty DB."""
+    with flask_app.app_context():
+        db.session.query(Quest).delete()
+        db.session.query(User).delete()
+        db.session.commit()
+        yield
+
+
+@pytest.fixture
+def client():
+    """A bare Flask test client (anonymous)."""
+    return flask_app.test_client()
+
+
+@pytest.fixture
+def make_user():
+    """Factory: create a User row with a known password and return it."""
+    def _make(username="alice", password="password1!", xp=0, streak=0):
+        u = User(username=username.lower(), xp=xp, streak=streak)
+        u.set_password(password)
+        db.session.add(u)
+        db.session.commit()
+        return u
+    return _make
+
+
+@pytest.fixture
+def login_as(client):
+    """Helper to populate the test client's session as if `user` had logged in."""
+    def _login(user):
+        with client.session_transaction() as sess:
+            sess["user_id"] = user.id
+            sess["username"] = user.username
+    return _login

--- a/studyquest/tests/test_routes.py
+++ b/studyquest/tests/test_routes.py
@@ -1,0 +1,102 @@
+"""Integration tests for the leaderboard, profile, and search routes I added."""
+import re
+
+
+def test_leaderboard_redirects_to_login_when_anonymous(client):
+    resp = client.get("/leaderboard", follow_redirects=False)
+    assert resp.status_code == 302
+    assert "/login" in resp.headers["Location"]
+
+
+def test_leaderboard_lists_users_in_xp_descending_order(client, make_user, login_as):
+    make_user("bob", xp=50)
+    make_user("alice", xp=200)
+    me = make_user("yui", xp=120)
+    login_as(me)
+
+    resp = client.get("/leaderboard")
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    # Extract /profile/<username> links in document order — that's the row order.
+    rows_in_order = re.findall(r"/profile/([a-z0-9]+)", body)
+    assert rows_in_order[:3] == ["alice", "yui", "bob"]
+
+
+def test_leaderboard_highlights_current_user_row(client, make_user, login_as):
+    make_user("other", xp=300)
+    me = make_user("me", xp=100)
+    login_as(me)
+
+    body = client.get("/leaderboard").get_data(as_text=True)
+    # the current-user css class only appears on the row of the logged-in user
+    assert "current-user" in body
+
+
+def test_profile_without_username_shows_my_journal(client, make_user, login_as):
+    me = make_user("me", xp=200)
+    login_as(me)
+    resp = client.get("/profile")
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert "My Journal" in body
+
+
+def test_profile_with_other_username_shows_their_username_in_title(client, make_user, login_as):
+    make_user("other", xp=300)
+    me = make_user("me", xp=50)
+    login_as(me)
+
+    resp = client.get("/profile/other")
+    body = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    # Jinja escapes the apostrophe; accept either form
+    assert "other&#39;s Journal" in body or "other's Journal" in body
+
+
+def test_profile_returns_404_for_unknown_username(client, make_user, login_as):
+    me = make_user("me")
+    login_as(me)
+    resp = client.get("/profile/ghost")
+    assert resp.status_code == 404
+
+
+def test_search_users_returns_empty_results_for_blank_query(client, make_user, login_as):
+    me = make_user("me")
+    login_as(me)
+    resp = client.get("/search_users?q=")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"results": []}
+
+
+def test_search_users_returns_substring_matches(client, make_user, login_as):
+    make_user("alice", xp=100)
+    make_user("alfred", xp=50)
+    make_user("bob", xp=10)
+    me = make_user("me")
+    login_as(me)
+
+    data = client.get("/search_users?q=al").get_json()
+    names = [r["username"] for r in data["results"]]
+    assert "alice" in names
+    assert "alfred" in names
+    assert "bob" not in names
+
+
+def test_search_users_results_carry_profile_url(client, make_user, login_as):
+    make_user("findable")
+    me = make_user("me")
+    login_as(me)
+
+    data = client.get("/search_users?q=find").get_json()
+    assert len(data["results"]) == 1
+    assert data["results"][0]["url"] == "/profile/findable"
+
+
+def test_search_users_caps_at_ten_results(client, make_user, login_as):
+    for i in range(15):
+        make_user(f"user{i:02d}", xp=i)
+    me = make_user("me")
+    login_as(me)
+
+    data = client.get("/search_users?q=user").get_json()
+    assert len(data["results"]) == 10

--- a/studyquest/tests/test_selenium.py
+++ b/studyquest/tests/test_selenium.py
@@ -1,0 +1,184 @@
+"""
+End-to-end browser tests using Selenium.
+
+These tests boot a real Flask server in a background subprocess on port 5050
+with a throwaway sqlite DB seeded with two users (alice, bob), then drive
+headless Chrome against it.
+
+Requirements:
+    pip install selenium
+    Chrome (or Chromium) installed locally.
+    Selenium 4.6+ has Selenium Manager built in, so chromedriver is fetched
+    automatically — no separate install needed.
+
+Run:
+    cd studyquest
+    pytest tests/test_selenium.py
+"""
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+selenium = pytest.importorskip("selenium")
+from selenium import webdriver
+from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+PORT = 5050
+BASE_URL = f"http://localhost:{PORT}"
+STUDYQUEST_DIR = Path(__file__).resolve().parent.parent
+SELENIUM_DB = STUDYQUEST_DIR / "selenium_test.db"
+
+
+def _wait_for_port(host, port, timeout=15):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def _seed_database():
+    """Seed two users into the selenium-test DB by spawning a small subprocess
+    that imports the app — that way we don't have to keep a duplicate schema
+    in sync with `models.py`."""
+    seed_code = (
+        f'import os\n'
+        f'os.environ["DATABASE_URL"] = "sqlite:///{SELENIUM_DB.as_posix()}"\n'
+        f'from app import app, db\n'
+        f'from app.models import User\n'
+        f'with app.app_context():\n'
+        f'    db.create_all()\n'
+        f'    if not User.query.filter_by(username="alice").first():\n'
+        f'        a = User(username="alice", xp=200)\n'
+        f'        a.set_password("password1!")\n'
+        f'        b = User(username="bob", xp=80)\n'
+        f'        b.set_password("password1!")\n'
+        f'        db.session.add_all([a, b])\n'
+        f'        db.session.commit()\n'
+    )
+    subprocess.run(
+        [sys.executable, "-c", seed_code],
+        cwd=str(STUDYQUEST_DIR),
+        check=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def live_server():
+    """Start a real Flask server in a subprocess for the duration of the module."""
+    if SELENIUM_DB.exists():
+        SELENIUM_DB.unlink()
+    _seed_database()
+
+    env = os.environ.copy()
+    env["DATABASE_URL"] = f"sqlite:///{SELENIUM_DB.as_posix()}"
+    env["SECRET_KEY"] = "selenium-test-secret"
+    env["FLASK_APP"] = "run.py"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "flask", "run", "--port", str(PORT), "--no-reload"],
+        cwd=str(STUDYQUEST_DIR),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    if not _wait_for_port("localhost", PORT, timeout=15):
+        proc.kill()
+        pytest.fail(f"Flask server failed to start on port {PORT}")
+
+    yield BASE_URL
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    if SELENIUM_DB.exists():
+        try:
+            SELENIUM_DB.unlink()
+        except OSError:
+            pass
+
+
+@pytest.fixture(scope="module")
+def driver(live_server):
+    options = Options()
+    options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--window-size=1280,900")
+    try:
+        drv = webdriver.Chrome(options=options)
+    except WebDriverException as e:
+        pytest.skip(f"Chrome / chromedriver not available: {e}")
+    drv.implicitly_wait(3)
+    yield drv
+    drv.quit()
+
+
+def _login(driver, base_url, username="alice", password="password1!"):
+    driver.get(base_url + "/login")
+    driver.find_element(By.NAME, "username").send_keys(username)
+    driver.find_element(By.NAME, "password").send_keys(password)
+    driver.find_element(By.CSS_SELECTOR, "button[type=submit]").click()
+    WebDriverWait(driver, 5).until(EC.url_contains("/dashboard"))
+
+
+def test_login_redirects_to_dashboard(driver, live_server):
+    _login(driver, live_server)
+    assert "/dashboard" in driver.current_url
+
+
+def test_leaderboard_shows_seeded_users(driver, live_server):
+    _login(driver, live_server)
+    driver.get(live_server + "/leaderboard")
+    body = driver.page_source
+    assert "alice" in body
+    assert "bob" in body
+
+
+def test_profile_self_shows_my_journal(driver, live_server):
+    _login(driver, live_server)
+    driver.get(live_server + "/profile")
+    title = driver.find_element(By.CLASS_NAME, "page-title").text
+    assert "My Journal" in title
+
+
+def test_profile_other_user_shows_their_username(driver, live_server):
+    _login(driver, live_server)
+    driver.get(live_server + "/profile/bob")
+    title = driver.find_element(By.CLASS_NAME, "page-title").text
+    assert "bob" in title.lower()
+
+
+def test_search_box_filters_users_via_ajax(driver, live_server):
+    _login(driver, live_server)
+    driver.get(live_server + "/leaderboard")
+    box = driver.find_element(By.ID, "user-search")
+    box.clear()
+    box.send_keys("bo")
+    WebDriverWait(driver, 5).until(
+        lambda d: "bob" in d.find_element(By.ID, "search-results").text
+    )
+
+
+def test_clicking_username_in_leaderboard_navigates_to_profile(driver, live_server):
+    _login(driver, live_server)
+    driver.get(live_server + "/leaderboard")
+    link = driver.find_element(By.CSS_SELECTOR, "a[href='/profile/bob']")
+    link.click()
+    WebDriverWait(driver, 5).until(EC.url_contains("/profile/bob"))
+    assert "bob" in driver.find_element(By.CLASS_NAME, "page-title").text.lower()

--- a/studyquest/tests/test_xp_helpers.py
+++ b/studyquest/tests/test_xp_helpers.py
@@ -1,0 +1,63 @@
+"""Unit tests for studyquest/app/xp_helpers.py."""
+from app.xp_helpers import (
+    AVATAR_POOL,
+    LEVEL_TITLES,
+    avatar_emoji,
+    level_title,
+    xp_into_level,
+    xp_to_level,
+    xp_to_next_level,
+)
+
+
+def test_xp_to_level_at_zero_returns_one():
+    assert xp_to_level(0) == 1
+
+
+def test_xp_to_level_just_below_threshold_stays_one():
+    assert xp_to_level(99) == 1
+
+
+def test_xp_to_level_at_thresholds_increments():
+    assert xp_to_level(100) == 2
+    assert xp_to_level(500) == 6
+    assert xp_to_level(1000) == 11
+
+
+def test_xp_to_level_handles_none_xp():
+    assert xp_to_level(None) == 1
+
+
+def test_xp_into_and_to_next_always_sum_to_100():
+    for xp in (0, 37, 99, 100, 250, 999, 5000):
+        assert xp_into_level(xp) + xp_to_next_level(xp) == 100
+
+
+def test_level_title_known_levels():
+    assert level_title(1) == "Tiny Sprout"
+    assert level_title(4) == "Blooming Scholar"
+    assert level_title(10) == "Grand Herbalist"
+
+
+def test_level_title_above_max_clamps_to_grand_herbalist():
+    assert level_title(11) == "Grand Herbalist"
+    assert level_title(99) == "Grand Herbalist"
+
+
+def test_avatar_emoji_is_deterministic_per_username():
+    assert avatar_emoji("alice") == avatar_emoji("alice")
+    assert avatar_emoji("bob") == avatar_emoji("bob")
+
+
+def test_avatar_emoji_returns_value_from_pool():
+    assert avatar_emoji("alice") in AVATAR_POOL
+    assert avatar_emoji("z") in AVATAR_POOL
+
+
+def test_avatar_emoji_handles_empty_or_none_username():
+    assert avatar_emoji("") == "🌸"
+    assert avatar_emoji(None) == "🌸"
+
+
+def test_level_titles_dict_has_ten_entries():
+    assert set(LEVEL_TITLES.keys()) == set(range(1, 11))


### PR DESCRIPTION
split out from #44 per the review request, so the tests can be reviewed separately from the feature code.

what's in here:
- 11 unit tests for xp_helpers (xp_to_level, level_title, avatar_emoji, plus edge cases)
- 10 integration tests for /leaderboard, /profile, /profile/<username>, and /search_users using the flask test client
- 6 selenium tests covering login → leaderboard → search → click row → profile flow
- pytest + selenium added to requirements.txt
- a quick "running the tests" section in README
- .venv/ + pytest cache + selenium_test.db added to .gitignore

heads up: these are pytest, not unittest. saw issue #47 right after pushing them. once the create_app + blueprint refactor lands i'll rewrite them in unittest using create_app(TestConfig) and TestCase + setUp/tearDown like the lecture shows. logic stays the same, just the framework changes.

the PR is targeted at feature/leaderboard-profile-search (#44) so the diff shows only the test changes. once #44 merges this will auto-retarget to main.

depends on #44.