### PR TITLE
Move profile xp bar inline width into CSS

### DIFF
--- a/studyquest/app/static/css/style.css
+++ b/studyquest/app/static/css/style.css
@@ -529,7 +529,8 @@ h4 { font-size: var(--text-lg);  font-weight: 600; }
 .xp-card-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: .5rem; }
 .xp-card-title { font-family: var(--font-display); font-size: 1rem; font-weight: 600; color: var(--bark-mid); }
 .xp-big-bar { height: 8px; background: var(--parchment-dark); border-radius: var(--radius-pill); overflow: hidden; margin: .375rem 0 .25rem; }
-.xp-big-fill { height: 100%; border-radius: var(--radius-pill); background: linear-gradient(90deg, var(--honey), var(--honey-light)); transition: width .9s cubic-bezier(.4,0,.2,1); }
+.xp-big-bar-spaced { margin-top: .5rem; }
+.xp-big-fill { width: var(--xp-progress, 0%); height: 100%; border-radius: var(--radius-pill); background: linear-gradient(90deg, var(--honey), var(--honey-light)); transition: width .9s cubic-bezier(.4,0,.2,1); }
 .xp-bar-labels { display: flex; justify-content: space-between; font-size: var(--text-xs); color: var(--bark-light); }
 
 .progress-bar { height: 6px; background: var(--parchment-mid); border-radius: var(--radius-pill); overflow: hidden; }

--- a/studyquest/app/templates/profile.html
+++ b/studyquest/app/templates/profile.html
@@ -46,8 +46,8 @@
       <strong style="color:var(--bark-mid)">{{ xp_into }}</strong> / 100 XP this level —
       <strong style="color:var(--bark-mid)">{{ xp_to_next }}</strong> XP to next level.
     </div>
-    <div class="xp-big-bar" style="margin-top:.5rem">
-      <div class="xp-big-fill" style="width:{{ xp_into }}%"></div>
+    <div class="xp-big-bar xp-big-bar-spaced">
+      <div class="xp-big-fill" style="--xp-progress: {{ xp_into }}%"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
addresses the discord ping about profile.html line 50.

profile.html line 50 had `style="width:{{ xp_into }}%"` which mixed a dynamic value into an inline style attribute, even though the rest of `.xp-big-fill`'s styling lives in `style.css`.

what changed:
- `.xp-big-fill` in `style.css` now sets `width: var(--xp-progress, 0%)`
- profile.html line 50 inline style is now `--xp-progress: {{ xp_into }}%`, so the template only sets the value, not the CSS rule
- the parent's `margin-top:.5rem` inline style is now a small `.xp-big-bar-spaced` class

no visual change. only `.xp-big-fill` location is profile.html so nothing else is affected.

closes #52