### PR TITLE
Show real level and xp in sidebar instead of hardcoded values

### DIFF
--- a/studyquest/app/__init__.py
+++ b/studyquest/app/__init__.py
@@ -26,4 +26,15 @@ def create_app(config_class=DeploymentConfig):
     from app.blueprints import main
     app.register_blueprint(main)
 
+    from app.xp_helpers import xp_to_level, xp_into_level, xp_to_next_level, level_title
+
+    @app.context_processor
+    def inject_xp_helpers():
+        return dict(
+            xp_to_level=xp_to_level,
+            xp_into_level=xp_into_level,
+            xp_to_next_level=xp_to_next_level,
+            level_title=level_title,
+        )
+
     return app

--- a/studyquest/app/templates/base.html
+++ b/studyquest/app/templates/base.html
@@ -34,8 +34,8 @@
     <!-- USER INFO -->
     <div>
       <p><strong>{{ current_user.username }}</strong></p>
-      <p>Level 3</p>
-      <p>120 / 200 XP</p>
+      <p>Level {{ xp_to_level(current_user.xp) }}</p>
+      <p>{{ xp_into_level(current_user.xp) }} / 100 XP</p>
     </div>
 
     <div>


### PR DESCRIPTION
the user info block in `base.html` had two hardcoded lines:

```html
<p>Level 3</p>
<p>120 / 200 XP</p>
```

so every logged-in user saw the same `Level 3` and `120 / 200 XP` no matter what their actual xp was.

what changed:
- added a `context_processor` in `create_app()` that exposes `xp_to_level`, `xp_into_level`, `xp_to_next_level`, and `level_title` from `xp_helpers` to all templates
- `base.html` sidebar now computes level and progress from `current_user.xp` at render time
- changed denominator from `/ 200` to `/ 100` since each level is 100 xp under the current `(xp // 100) + 1` formula in `dashboard()` and `xp_helpers`

no schema or routing change. only runs inside `{% if current_user.is_authenticated %}` so anonymous users are unaffected.

closes #54