### PR TITLE
Add descriptive messages to all test assertions

### DIFF
--- a/studyquest/tests/unit/test_leaderboard.py
+++ b/studyquest/tests/unit/test_leaderboard.py
@@ -37,29 +37,53 @@ class LeaderboardTests(unittest.TestCase):
 
     def test_anonymous_user_is_redirected_to_login(self):
         response = self.client.get("/leaderboard", follow_redirects=False)
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/login", response.headers["Location"])
+        self.assertEqual(
+            response.status_code, 302,
+            "Anonymous user hitting /leaderboard should be redirected (302), not served the page"
+        )
+        self.assertIn(
+            "/login", response.headers["Location"],
+            "Redirect target for unauthenticated /leaderboard should point at /login"
+        )
 
     def test_ranking_is_xp_descending(self):
         self._login(self.me)
         response = self.client.get("/leaderboard")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.status_code, 200,
+            "Logged-in user should get a 200 OK from /leaderboard"
+        )
         body = response.get_data(as_text=True)
         # Each row links to /profile/<username>; document order = row order
         order = re.findall(r"/profile/([a-z0-9]+)", body)
-        self.assertEqual(order[:3], ["alice", "me", "bob"])
+        self.assertEqual(
+            order[:3], ["alice", "me", "bob"],
+            "Leaderboard rows should be ordered by xp descending (alice 200, me 120, bob 80)"
+        )
 
     def test_current_user_row_has_highlight_class(self):
         self._login(self.me)
         body = self.client.get("/leaderboard").get_data(as_text=True)
-        self.assertIn("current-user", body)
+        self.assertIn(
+            "current-user", body,
+            "The logged-in user's row should carry the 'current-user' CSS class for highlight"
+        )
 
     def test_top_three_get_medal_emojis(self):
         self._login(self.me)
         body = self.client.get("/leaderboard").get_data(as_text=True)
-        self.assertIn("🥇", body)
-        self.assertIn("🥈", body)
-        self.assertIn("🥉", body)
+        self.assertIn(
+            "🥇", body,
+            "Rank 1 row should render the gold medal emoji"
+        )
+        self.assertIn(
+            "🥈", body,
+            "Rank 2 row should render the silver medal emoji"
+        )
+        self.assertIn(
+            "🥉", body,
+            "Rank 3 row should render the bronze medal emoji"
+        )
 
 
 if __name__ == "__main__":

--- a/studyquest/tests/unit/test_profile.py
+++ b/studyquest/tests/unit/test_profile.py
@@ -34,13 +34,22 @@ class ProfileTests(unittest.TestCase):
 
     def test_anonymous_user_is_redirected_to_login(self):
         response = self.client.get("/profile", follow_redirects=False)
-        self.assertEqual(response.status_code, 302)
-        self.assertIn("/login", response.headers["Location"])
+        self.assertEqual(
+            response.status_code, 302,
+            "Anonymous user hitting /profile should be redirected (302), not served the page"
+        )
+        self.assertIn(
+            "/login", response.headers["Location"],
+            "Redirect target for unauthenticated /profile should point at /login"
+        )
 
     def test_own_profile_shows_my_journal(self):
         self._login(self.alice)
         body = self.client.get("/profile").get_data(as_text=True)
-        self.assertIn("My Journal", body)
+        self.assertIn(
+            "My Journal", body,
+            "Visiting /profile while logged in should show 'My Journal' as the page title"
+        )
 
     def test_other_user_profile_shows_their_username_in_title(self):
         self._login(self.alice)
@@ -48,13 +57,16 @@ class ProfileTests(unittest.TestCase):
         # Jinja escapes the apostrophe, accept either form
         self.assertTrue(
             "bob&#39;s Journal" in body or "bob's Journal" in body,
-            "Expected 'bob's Journal' in profile page title",
+            "Profile page for another user should show '<username>'s Journal' as the title"
         )
 
     def test_profile_returns_404_for_unknown_username(self):
         self._login(self.alice)
         response = self.client.get("/profile/ghost")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.status_code, 404,
+            "Profile route should 404 for a username that does not exist in the database"
+        )
 
 
 if __name__ == "__main__":

--- a/studyquest/tests/unit/test_search.py
+++ b/studyquest/tests/unit/test_search.py
@@ -39,13 +39,22 @@ class SearchUsersTests(unittest.TestCase):
 
     def test_anonymous_user_is_redirected_to_login(self):
         response = self.client.get("/search_users?q=al", follow_redirects=False)
-        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.status_code, 302,
+            "Anonymous user hitting /search_users should be redirected, not get JSON results"
+        )
 
     def test_empty_query_returns_empty_results(self):
         self._login(self.me)
         response = self.client.get("/search_users?q=")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), {"results": []})
+        self.assertEqual(
+            response.status_code, 200,
+            "Logged-in user with empty query should get 200, not redirect or error"
+        )
+        self.assertEqual(
+            response.get_json(), {"results": []},
+            "Empty query should return an empty results list, not all users"
+        )
 
     def test_substring_match_returns_matching_users_only(self):
         self._add_user("alice", xp=100)
@@ -55,23 +64,41 @@ class SearchUsersTests(unittest.TestCase):
 
         data = self.client.get("/search_users?q=al").get_json()
         names = [r["username"] for r in data["results"]]
-        self.assertIn("alice", names)
-        self.assertIn("alfred", names)
-        self.assertNotIn("bob", names)
+        self.assertIn(
+            "alice", names,
+            "'alice' should match the substring 'al'"
+        )
+        self.assertIn(
+            "alfred", names,
+            "'alfred' should match the substring 'al'"
+        )
+        self.assertNotIn(
+            "bob", names,
+            "'bob' does not contain 'al' and should not appear in results"
+        )
 
     def test_results_carry_a_profile_url(self):
         self._add_user("findable")
         self._login(self.me)
         data = self.client.get("/search_users?q=find").get_json()
-        self.assertEqual(len(data["results"]), 1)
-        self.assertEqual(data["results"][0]["url"], "/profile/findable")
+        self.assertEqual(
+            len(data["results"]), 1,
+            "Substring 'find' should match exactly one user, 'findable'"
+        )
+        self.assertEqual(
+            data["results"][0]["url"], "/profile/findable",
+            "Each search result should include the profile URL for that user"
+        )
 
     def test_results_capped_at_ten_per_query(self):
         for i in range(15):
             self._add_user(f"user{i:02d}", xp=i)
         self._login(self.me)
         data = self.client.get("/search_users?q=user").get_json()
-        self.assertEqual(len(data["results"]), 10)
+        self.assertEqual(
+            len(data["results"]), 10,
+            "search_users should cap results at 10 per query to avoid heavy payloads"
+        )
 
 
 if __name__ == "__main__":

--- a/studyquest/tests/unit/test_xp_helpers.py
+++ b/studyquest/tests/unit/test_xp_helpers.py
@@ -15,46 +15,103 @@ class XpHelpersTests(unittest.TestCase):
     """Pure-function tests for the xp_helpers module."""
 
     def test_xp_to_level_at_zero_returns_one(self):
-        self.assertEqual(xp_to_level(0), 1)
+        self.assertEqual(
+            xp_to_level(0), 1,
+            "A user with 0 XP should be at Level 1"
+        )
 
     def test_xp_to_level_below_first_threshold_stays_one(self):
-        self.assertEqual(xp_to_level(99), 1)
+        self.assertEqual(
+            xp_to_level(99), 1,
+            "A user with 99 XP should still be at Level 1 (next threshold is 100)"
+        )
 
     def test_xp_to_level_at_thresholds_increments(self):
-        self.assertEqual(xp_to_level(100), 2)
-        self.assertEqual(xp_to_level(500), 6)
-        self.assertEqual(xp_to_level(1000), 11)
+        self.assertEqual(
+            xp_to_level(100), 2,
+            "100 XP should put the user at Level 2"
+        )
+        self.assertEqual(
+            xp_to_level(500), 6,
+            "500 XP should put the user at Level 6"
+        )
+        self.assertEqual(
+            xp_to_level(1000), 11,
+            "1000 XP should put the user at Level 11"
+        )
 
     def test_xp_to_level_handles_none(self):
-        self.assertEqual(xp_to_level(None), 1)
+        self.assertEqual(
+            xp_to_level(None), 1,
+            "xp_to_level should treat None as 0 XP and return Level 1, not raise"
+        )
 
     def test_xp_into_and_to_next_always_sum_to_100(self):
         for xp in (0, 37, 99, 100, 250, 999, 5000):
-            self.assertEqual(xp_into_level(xp) + xp_to_next_level(xp), 100)
+            self.assertEqual(
+                xp_into_level(xp) + xp_to_next_level(xp), 100,
+                f"xp_into_level + xp_to_next_level should equal 100 for any xp (failed at xp={xp})"
+            )
 
     def test_level_title_known_levels(self):
-        self.assertEqual(level_title(1), "Tiny Sprout")
-        self.assertEqual(level_title(4), "Blooming Scholar")
-        self.assertEqual(level_title(10), "Grand Herbalist")
+        self.assertEqual(
+            level_title(1), "Tiny Sprout",
+            "Level 1 should be titled 'Tiny Sprout'"
+        )
+        self.assertEqual(
+            level_title(4), "Blooming Scholar",
+            "Level 4 should be titled 'Blooming Scholar'"
+        )
+        self.assertEqual(
+            level_title(10), "Grand Herbalist",
+            "Level 10 should be titled 'Grand Herbalist'"
+        )
 
     def test_level_title_above_max_clamps(self):
-        self.assertEqual(level_title(11), "Grand Herbalist")
-        self.assertEqual(level_title(99), "Grand Herbalist")
+        self.assertEqual(
+            level_title(11), "Grand Herbalist",
+            "Level 11 should clamp to the max title 'Grand Herbalist'"
+        )
+        self.assertEqual(
+            level_title(99), "Grand Herbalist",
+            "Level 99 should clamp to the max title 'Grand Herbalist'"
+        )
 
     def test_avatar_emoji_is_deterministic(self):
-        self.assertEqual(avatar_emoji("alice"), avatar_emoji("alice"))
-        self.assertEqual(avatar_emoji("bob"), avatar_emoji("bob"))
+        self.assertEqual(
+            avatar_emoji("alice"), avatar_emoji("alice"),
+            "avatar_emoji should return the same emoji every time for the same username"
+        )
+        self.assertEqual(
+            avatar_emoji("bob"), avatar_emoji("bob"),
+            "avatar_emoji should be deterministic for 'bob' across calls"
+        )
 
     def test_avatar_emoji_returns_value_from_pool(self):
-        self.assertIn(avatar_emoji("alice"), AVATAR_POOL)
-        self.assertIn(avatar_emoji("z"), AVATAR_POOL)
+        self.assertIn(
+            avatar_emoji("alice"), AVATAR_POOL,
+            "avatar_emoji output for 'alice' should be a value from AVATAR_POOL"
+        )
+        self.assertIn(
+            avatar_emoji("z"), AVATAR_POOL,
+            "avatar_emoji output for 'z' should be a value from AVATAR_POOL"
+        )
 
     def test_avatar_emoji_handles_empty_or_none(self):
-        self.assertEqual(avatar_emoji(""), "🌸")
-        self.assertEqual(avatar_emoji(None), "🌸")
+        self.assertEqual(
+            avatar_emoji(""), "🌸",
+            "avatar_emoji should fall back to '🌸' for empty string"
+        )
+        self.assertEqual(
+            avatar_emoji(None), "🌸",
+            "avatar_emoji should fall back to '🌸' for None"
+        )
 
     def test_level_titles_has_ten_entries(self):
-        self.assertEqual(set(LEVEL_TITLES.keys()), set(range(1, 11)))
+        self.assertEqual(
+            set(LEVEL_TITLES.keys()), set(range(1, 11)),
+            "LEVEL_TITLES should have entries for levels 1 through 10"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
addresses #61. every assert in tests/unit/ now has a descriptive message as the third argument, so when a test fails the unittest output points at exactly which behaviour broke without having to read the test body.

example:

```python
# before
self.assertEqual(xp_to_level(100), 2)

# after
self.assertEqual(
    xp_to_level(100), 2,
    "100 XP should put the user at Level 2"
)
```

scope: 4 files under tests/unit/ (test_xp_helpers.py, test_leaderboard.py, test_profile.py, test_search.py), ~46 assertions updated. no logic changes, just added the message argument.

all 24 tests still pass locally.

closes #61