### PR TITLE
Load .env on startup and drop the hardcoded SECRET_KEY fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SECRET_KEY=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Thumbs.db
 # database
 instance/
 app.db
+
+# environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -69,11 +69,19 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Set a secret key (or use a `.env` file in the repo root):
+Copy `.env.example` to `.env` in the repo root and set a secret key:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` so `SECRET_KEY` is something long and random:
 
 ```
 SECRET_KEY=anything-long-and-random
 ```
+
+The app loads `.env` automatically and will refuse to start if `SECRET_KEY` is not set.
 
 Then from inside `studyquest/`:
 

--- a/studyquest/app/__init__.py
+++ b/studyquest/app/__init__.py
@@ -1,3 +1,6 @@
+from dotenv import load_dotenv
+load_dotenv()
+
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
@@ -19,6 +22,11 @@ login_manager.login_view = "main.login"
 def create_app(config_class=DeploymentConfig):
     app = Flask(__name__)
     app.config.from_object(config_class)
+
+    if not app.config.get("SECRET_KEY"):
+        raise RuntimeError(
+            "SECRET_KEY is not set. Copy .env.example to .env and set a value."
+        )
 
     db.init_app(app)
     csrf.init_app(app)

--- a/studyquest/app/config.py
+++ b/studyquest/app/config.py
@@ -3,7 +3,7 @@ import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY") or "dev-secret-key"
+    SECRET_KEY = os.environ.get("SECRET_KEY")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 class DeploymentConfig(Config):
@@ -11,5 +11,6 @@ class DeploymentConfig(Config):
 
 class TestConfig(Config):
     TESTING = True
+    SECRET_KEY = "test-secret-key"
     SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False


### PR DESCRIPTION
Closes #72.

config.py previously fell back to a hardcoded `"dev-secret-key"` if `SECRET_KEY` wasn't set, which is a guessable session signing key. python-dotenv was also in requirements.txt but never actually called, so .env files weren't loading.

Changes:
- `load_dotenv()` at the top of `app/__init__.py` so a `.env` file is picked up automatically
- added `.env.example` with placeholders (`SECRET_KEY=changeme`)
- dropped the `or "dev-secret-key"` fallback - `SECRET_KEY` now comes purely from the environment, and `create_app` raises if it isn't set so the app fails loud
- `TestConfig` keeps its own static key so the test suite still runs without a .env
- `.env` added to .gitignore
- README setup steps now mention copying `.env.example` -> `.env`

Tested locally: all 40 unit tests still pass, app refuses to start with no SECRET_KEY, and starts fine with a .env present.